### PR TITLE
Update settings.py to handle colored text for Windows

### DIFF
--- a/lib/parse/settings.py
+++ b/lib/parse/settings.py
@@ -13,6 +13,16 @@ import re
 import string
 import sys
 
+#enable VT100 emulation for colored text output on windows platforms
+if sys.platform.startswith('win'):
+	import ctypes
+	kernel32 = ctypes.WinDLL('kernel32')
+	hStdOut = kernel32.GetStdHandle(-11)
+	mode = ctypes.c_ulong()
+	kernel32.GetConsoleMode(hStdOut, ctypes.byref(mode))
+	mode.value |= 4
+	kernel32.SetConsoleMode(hStdOut, mode)
+
 from lib.parse.colors import white, green, red, yellow, end, info, que, bad, good, run
 from pip._internal import main as pip
 


### PR DESCRIPTION
The ANSI escape sequences for colored text output does not work with the default Windows command prompt CLI unless VT100 emulation is enabled. I added this support for VT100 with Windows CLI directly into the program. Other solutions exist such as python modules or bundling components which modify the default ANSI.sys CLI functionality on Windows. Ultimately, I used this quick method because I felt that this is the fasted and most straightforward solution for adding the colored text output functionality on Windows.

I thought I would share this in case you want to merge the functionality. You may prefer to insert this functionality into the Cloudmare program in a different way. I have a software engineering background and use python a lot; however, I am more accustomed to only writing one file scripts when it comes to writing python. So, I also wanted to add a disclaimer that this may not be the cleanest way to add the code enabling this functionality into Cloudmare.