### PR TITLE
Require python3

### DIFF
--- a/Cloudmare.py
+++ b/Cloudmare.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 # By: MrH0wl
 

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ $ git clone https://github.com/MrH0wl/Cloudmare.git
 
 ```
 $ cd Cloudmare
-$ python Cloudmare.py -h or python Cloudmare.py -hh
+$ python3 Cloudmare.py -h or python3 Cloudmare.py -hh
 ```
 
 3) Run Cloudmare (see [Usage](#usage) below for more detail)
 
 ```
-$ python Cloudmare.py target.site
+$ python3 Cloudmare.py target.site
 ```
 
 ## Usage
@@ -37,7 +37,7 @@ $ python Cloudmare.py target.site
 
 ## Compatibility
 
-Tested on Python 2.7 and Python=<3.7, working on Linux and Windows. Feel free to [open an issue] if you have bug reports or questions. If you want to collaborate, you're welcome.
+Tested on Python=<3.7, working on Linux and Windows. Feel free to [open an issue] if you have bug reports or questions. If you want to collaborate, you're welcome.
 
 [open an issue]: https://github.com/MrH0wl/Cloudmare/issues/new
 


### PR DESCRIPTION
As highlighted in issue #25 python2 is dead and the longer scripts try to stay compatible with it, the more errors it's going to cause.